### PR TITLE
Create CircleProgressView.podspec

### DIFF
--- a/CircleProgressView.podspec
+++ b/CircleProgressView.podspec
@@ -9,5 +9,5 @@ Pod::Spec.new do |s|
   s.platform = :ios
   s.requires_arc = true
   s.source_files = 'CircleProgressView/*'
-  s.frameworks   = 'QuartzCore'
+  s.frameworks   = ''
 end


### PR DESCRIPTION
I added a PodSpec for you to be able to support CocoaPod integration.
Love your work! Nice job on supporting XC6 IB designables!

You'll need to follow these instructions to actually get it up on the CocoaPods trunk however!:
http://guides.cocoapods.org/making/getting-setup-with-trunk.html
