### PR TITLE
Fixed bug happening on 32-bit devices when progress is 0.

### DIFF
--- a/ProgressView/CircleProgressView.m
+++ b/ProgressView/CircleProgressView.m
@@ -122,7 +122,7 @@ struct Constants {              // Default Values = Private
     CGRect innerRect = CGRectInset(rect, self.trackBorderWidth, self.trackBorderWidth);
     
     self.internalProgress = (self.internalProgress/1.0) == 0.0 ? self.constants.minimumValue : self.progress;
-    self.internalProgress = (self.internalProgress/1.0) == 1.0 ? self.constants.maximumValue : self.progress;
+    self.internalProgress = (self.internalProgress/1.0) == 1.0 ? self.constants.maximumValue : self.internalProgress;
     self.internalProgress = self.clockwise ?
                             (-self.constants.twoSeventyDegrees + ((1.0 - self.internalProgress) * self.constants.circleDegress)) :
                             (self.constants.ninetyDegrees - ((1.0 - self.internalProgress) * self.constants.circleDegress));

--- a/ProgressView/CircleProgressView.swift
+++ b/ProgressView/CircleProgressView.swift
@@ -82,7 +82,7 @@ import UIKit
         let innerRect = CGRectInset(rect, trackBorderWidth, trackBorderWidth)
         
         internalProgress = (internalProgress/1.0) == 0.0 ? constants.minimumValue : progress
-        internalProgress = (internalProgress/1.0) == 1.0 ? constants.maximumValue : progress
+        internalProgress = (internalProgress/1.0) == 1.0 ? constants.maximumValue : internalProgress
         internalProgress = clockwise ?
                                 (-constants.twoSeventyDegrees + ((1.0 - internalProgress) * constants.circleDegress)) :
                                 (constants.ninetyDegrees - ((1.0 - internalProgress) * constants.circleDegress))


### PR DESCRIPTION
Fixed bug happening on 32-bit devices when progress is 0. ProgressView was behaving like it was 100%.