### PR TITLE
Support UIColor.clear for transparency

### DIFF
--- a/CircleProgressView/CircleProgressView.swift
+++ b/CircleProgressView/CircleProgressView.swift
@@ -24,7 +24,7 @@ import UIKit
 
     fileprivate var displayLink: CADisplayLink?
     fileprivate var destinationProgress: Double = 0.0
-    
+
     @IBInspectable open var progress: Double = 0.000001 {
         didSet {
             internalProgress = progress
@@ -67,7 +67,7 @@ import UIKit
     @IBInspectable open var centerFillColor: UIColor = UIColor.white {
         didSet { setNeedsDisplay() }
     }
-    
+
     @IBInspectable open var centerImage: UIImage? {
         didSet { setNeedsDisplay() }
     }
@@ -87,38 +87,40 @@ import UIKit
         internalInit()
         self.addSubview(contentView)
     }
-    
+
     func internalInit() {
         displayLink = CADisplayLink(target: self, selector: #selector(CircleProgressView.displayLinkTick))
         displayLink?.add(to: RunLoop.main, forMode: .defaultRunLoopMode)
         displayLink?.isPaused = true
     }
-    
+
     override open func draw(_ rect: CGRect) {
-        
+
         super.draw(rect)
-        
+
         let innerRect = rect.insetBy(dx: trackBorderWidth, dy: trackBorderWidth)
-        
+
         internalProgress = (internalProgress/1.0) == 0.0 ? constants.minimumValue : progress
         internalProgress = (internalProgress/1.0) == 1.0 ? constants.maximumValue : internalProgress
         internalProgress = clockwise ?
                                 (-constants.twoSeventyDegrees + ((1.0 - internalProgress) * constants.circleDegress)) :
                                 (constants.ninetyDegrees - ((1.0 - internalProgress) * constants.circleDegress))
-        
+
         let context = UIGraphicsGetCurrentContext()
-        
+
         // background Drawing
-        trackBackgroundColor.setFill()
         let circlePath = UIBezierPath(ovalIn: CGRect(x: innerRect.minX, y: innerRect.minY, width: innerRect.width, height: innerRect.height))
-        circlePath.fill();
-        
+        if trackBackgroundColor != UIColor.clear {
+            trackBackgroundColor.setFill()
+            circlePath.fill();
+        }
+
         if trackBorderWidth > 0 {
             circlePath.lineWidth = trackBorderWidth
             trackBorderColor.setStroke()
             circlePath.stroke()
         }
-        
+
         // progress Drawing
         let progressPath = UIBezierPath()
         let progressRect: CGRect = CGRect(x: innerRect.minX, y: innerRect.minY, width: innerRect.width, height: innerRect.height)
@@ -126,29 +128,32 @@ import UIKit
         let radius = progressRect.width / 2.0
         let startAngle:CGFloat = clockwise ? CGFloat(-internalProgress * M_PI / 180.0) : CGFloat(constants.twoSeventyDegrees * M_PI / 180)
         let endAngle:CGFloat = clockwise ? CGFloat(constants.twoSeventyDegrees * M_PI / 180) : CGFloat(-internalProgress * M_PI / 180.0)
-        
+
         progressPath.addArc(withCenter: center, radius:radius, startAngle:startAngle, endAngle:endAngle, clockwise:!clockwise)
-        progressPath.addLine(to: CGPoint(x: progressRect.midX, y: progressRect.midY))
+        progressPath.addArc(withCenter: center, radius:radius-trackWidth, startAngle:endAngle, endAngle:startAngle, clockwise:clockwise)
+        //progressPath.addLine(to: CGPoint(x: progressRect.midX, y: progressRect.midY))
         progressPath.close()
-        
+
         context?.saveGState()
-        
+
         progressPath.addClip()
-        
-        if trackImage != nil {
-            trackImage!.draw(in: innerRect)
-        } else {
+
+        if let trackImage = trackImage {
+            trackImage.draw(in: innerRect)
+        } else if trackFillColor != UIColor.clear {
             trackFillColor.setFill()
             circlePath.fill()
         }
-        
+
         context?.restoreGState()
-        
+
         // center Drawing
         let centerPath = UIBezierPath(ovalIn: CGRect(x: innerRect.minX + trackWidth, y: innerRect.minY + trackWidth, width: innerRect.width - (2 * trackWidth), height: innerRect.height - (2 * trackWidth)))
-        centerFillColor.setFill()
-        centerPath.fill()
-        
+        if centerFillColor != UIColor.clear {
+            centerFillColor.setFill()
+            centerPath.fill()
+        }
+
         if let centerImage = centerImage {
             context?.saveGState()
             centerPath.addClip()
@@ -160,11 +165,11 @@ import UIKit
             contentView.layer.mask = layer
         }
     }
-    
+
     //MARK: - Progress Update
-    
+
     open func setProgress(_ newProgress: Double, animated: Bool) {
-        
+
         if animated {
             destinationProgress = newProgress
             displayLink?.isPaused = false
@@ -172,11 +177,11 @@ import UIKit
             progress = newProgress
         }
     }
-    
+
     //MARK: - CADisplayLink Tick
-    
+
     internal func displayLinkTick() {
-            
+
         let renderTime = refreshRate.isZero ? displayLink!.duration : refreshRate
 
         if destinationProgress > progress {
@@ -194,6 +199,6 @@ import UIKit
             displayLink?.isPaused = true
         }
     }
-    
-    
+
+
 }

--- a/ProgressView/CircleProgressView.swift
+++ b/ProgressView/CircleProgressView.swift
@@ -24,7 +24,7 @@ import UIKit
 
     fileprivate var displayLink: CADisplayLink?
     fileprivate var destinationProgress: Double = 0.0
-    
+
     @IBInspectable open var progress: Double = 0.000001 {
         didSet {
             internalProgress = progress
@@ -67,7 +67,7 @@ import UIKit
     @IBInspectable open var centerFillColor: UIColor = UIColor.white {
         didSet { setNeedsDisplay() }
     }
-    
+
     @IBInspectable open var centerImage: UIImage? {
         didSet { setNeedsDisplay() }
     }
@@ -87,38 +87,40 @@ import UIKit
         internalInit()
         self.addSubview(contentView)
     }
-    
+
     func internalInit() {
         displayLink = CADisplayLink(target: self, selector: #selector(CircleProgressView.displayLinkTick))
         displayLink?.add(to: RunLoop.main, forMode: .defaultRunLoopMode)
         displayLink?.isPaused = true
     }
-    
+
     override open func draw(_ rect: CGRect) {
-        
+
         super.draw(rect)
-        
+
         let innerRect = rect.insetBy(dx: trackBorderWidth, dy: trackBorderWidth)
-        
+
         internalProgress = (internalProgress/1.0) == 0.0 ? constants.minimumValue : progress
         internalProgress = (internalProgress/1.0) == 1.0 ? constants.maximumValue : internalProgress
         internalProgress = clockwise ?
                                 (-constants.twoSeventyDegrees + ((1.0 - internalProgress) * constants.circleDegress)) :
                                 (constants.ninetyDegrees - ((1.0 - internalProgress) * constants.circleDegress))
-        
+
         let context = UIGraphicsGetCurrentContext()
-        
+
         // background Drawing
-        trackBackgroundColor.setFill()
         let circlePath = UIBezierPath(ovalIn: CGRect(x: innerRect.minX, y: innerRect.minY, width: innerRect.width, height: innerRect.height))
-        circlePath.fill();
-        
+        if trackBackgroundColor != UIColor.clear {
+            trackBackgroundColor.setFill()
+            circlePath.fill();
+        }
+
         if trackBorderWidth > 0 {
             circlePath.lineWidth = trackBorderWidth
             trackBorderColor.setStroke()
             circlePath.stroke()
         }
-        
+
         // progress Drawing
         let progressPath = UIBezierPath()
         let progressRect: CGRect = CGRect(x: innerRect.minX, y: innerRect.minY, width: innerRect.width, height: innerRect.height)
@@ -126,29 +128,32 @@ import UIKit
         let radius = progressRect.width / 2.0
         let startAngle:CGFloat = clockwise ? CGFloat(-internalProgress * M_PI / 180.0) : CGFloat(constants.twoSeventyDegrees * M_PI / 180)
         let endAngle:CGFloat = clockwise ? CGFloat(constants.twoSeventyDegrees * M_PI / 180) : CGFloat(-internalProgress * M_PI / 180.0)
-        
+
         progressPath.addArc(withCenter: center, radius:radius, startAngle:startAngle, endAngle:endAngle, clockwise:!clockwise)
-        progressPath.addLine(to: CGPoint(x: progressRect.midX, y: progressRect.midY))
+        progressPath.addArc(withCenter: center, radius:radius-trackWidth, startAngle:endAngle, endAngle:startAngle, clockwise:clockwise)
+        //progressPath.addLine(to: CGPoint(x: progressRect.midX, y: progressRect.midY))
         progressPath.close()
-        
+
         context?.saveGState()
-        
+
         progressPath.addClip()
-        
-        if trackImage != nil {
-            trackImage!.draw(in: innerRect)
-        } else {
+
+        if let trackImage = trackImage {
+            trackImage.draw(in: innerRect)
+        } else if trackFillColor != UIColor.clear {
             trackFillColor.setFill()
             circlePath.fill()
         }
-        
+
         context?.restoreGState()
-        
+
         // center Drawing
         let centerPath = UIBezierPath(ovalIn: CGRect(x: innerRect.minX + trackWidth, y: innerRect.minY + trackWidth, width: innerRect.width - (2 * trackWidth), height: innerRect.height - (2 * trackWidth)))
-        centerFillColor.setFill()
-        centerPath.fill()
-        
+        if centerFillColor != UIColor.clear {
+            centerFillColor.setFill()
+            centerPath.fill()
+        }
+
         if let centerImage = centerImage {
             context?.saveGState()
             centerPath.addClip()
@@ -160,11 +165,11 @@ import UIKit
             contentView.layer.mask = layer
         }
     }
-    
+
     //MARK: - Progress Update
-    
+
     open func setProgress(_ newProgress: Double, animated: Bool) {
-        
+
         if animated {
             destinationProgress = newProgress
             displayLink?.isPaused = false
@@ -172,11 +177,11 @@ import UIKit
             progress = newProgress
         }
     }
-    
+
     //MARK: - CADisplayLink Tick
-    
+
     internal func displayLinkTick() {
-            
+
         let renderTime = refreshRate.isZero ? displayLink!.duration : refreshRate
 
         if destinationProgress > progress {
@@ -194,6 +199,6 @@ import UIKit
             displayLink?.isPaused = true
         }
     }
-    
-    
+
+
 }


### PR DESCRIPTION
By supporting `UIColor.clear`, the control can only paint the parts with explicit color set. This also requires drawing the circle with two arcs, to avoid drawing over the inner circle.

I see now that the diff removed trailing whitespace.