### PR TITLE
Exclude app delegate file from pod.

### DIFF
--- a/CircleProgressView.podspec
+++ b/CircleProgressView.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.platform = :ios
   s.requires_arc = true
   s.source_files = 'CircleProgressView/*.swift'
+  s.exclude_files = 'CircleProgressView/AppDelegate.swift'
   s.ios.deployment_target = "8.0"
   s.swift_version = '4.2'
 end


### PR DESCRIPTION
Exclude app delegate file from pod to avoid this error: `Duplicate interface definition for class 'AppDelegate'.`